### PR TITLE
Add manifest.json file and context menu

### DIFF
--- a/js/init.js
+++ b/js/init.js
@@ -1,0 +1,17 @@
+
+var createProperties = {
+    contexts: ['all'],
+    id:       'contextMenuItemCreate',
+    title:    'Add to Pull Reaction',
+    type:     'normal'
+};
+var contextMenuItemCreate = chrome.contextMenus.create(createProperties, function() {
+    /**
+     * TODO: chrome.runtime.lastError object handling when something goes
+     *       wrong during contextMenu creation process
+     *
+     *       if (typeof chrome.runtime.lastError != 'undefined') {
+     *          ...
+     *       }
+     */
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,15 @@
+{
+    "manifest_version": 2,
+    "name": "Pull Reaction",
+    "version": "0.0.1",
+
+    "background" : {
+        "persistent": false,
+        "scripts": [
+            "js/init.js"
+        ]
+    },
+    "permissions": [
+        "contextMenus"
+    ]
+}


### PR DESCRIPTION
- Added initial manifest.json prototype with
  basic configuration parameters.
- Added init.js script responsible to create the
  context menu item when user right-click on a
  page.

Current commit will produce the following result (wish GitHub could handle image :
![screen-shot-2014-10-01-at-20 23 46](https://cloud.githubusercontent.com/assets/6195629/4482088/102f182e-49a5-11e4-84be-1dcee8b1a8ef.png)
