### PR TITLE
Add content_scripts capability to manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,6 +9,11 @@
             "js/init.js"
         ]
     },
+    "content_scripts": [
+        {
+            "matches": ["<all_urls>"]
+        }
+    ],
     "permissions": [
         "contextMenus"
     ]


### PR DESCRIPTION
Added content_scripts capability to manifest.json
file in order let the extension interact with opened
pages. Scope is set to all URLs which means that the
extension should be able to interact with every page
on every website across the web.
