### PR TITLE
Enable context menu item only on gifs

### DIFF
--- a/js/init.js
+++ b/js/init.js
@@ -11,7 +11,7 @@ var contextMenuItemCreate = chrome.contextMenus.create(createProperties, functio
      *       wrong during contextMenu creation process
      *
      *       if (typeof chrome.runtime.lastError != 'undefined') {
-             *          ...
-             *       }
+     *          ...
+     *       }
      */
 });

--- a/js/init.js
+++ b/js/init.js
@@ -1,7 +1,7 @@
-
 var createProperties = {
-    contexts: ['all'],
+    contexts: ['image'],
     id:       'contextMenuItemCreate',
+    targetUrlPatterns: ["*://*/*gif"],
     title:    'Add to Pull Reaction',
     type:     'normal'
 };
@@ -11,7 +11,7 @@ var contextMenuItemCreate = chrome.contextMenus.create(createProperties, functio
      *       wrong during contextMenu creation process
      *
      *       if (typeof chrome.runtime.lastError != 'undefined') {
-     *          ...
-     *       }
+             *          ...
+             *       }
      */
 });


### PR DESCRIPTION
Extension will now show the context menu item only when an image tag with the src attribute ending with "gif" has been right clicked. 
The manifest.json file was also modified as there's currently no need to use content scripts to accomplish this goal.
